### PR TITLE
Update telemetry code

### DIFF
--- a/rust/otap-dataflow/crates/controller/src/lib.rs
+++ b/rust/otap-dataflow/crates/controller/src/lib.rs
@@ -92,7 +92,7 @@ impl<PData: 'static + Clone + Send + Sync + std::fmt::Debug> Controller<PData> {
 
         // Start the metrics aggregation
         let telemetry_registry = telemetry_system.registry();
-        let (internal_collector, otel_shutdown_handle) = telemetry_system.into_parts();
+        let internal_collector = telemetry_system.collector();
         let metrics_agg_handle =
             spawn_thread_local_task("metrics-aggregator", move |cancellation_token| {
                 internal_collector.run(cancellation_token)
@@ -256,7 +256,7 @@ impl<PData: 'static + Clone + Send + Sync + std::fmt::Debug> Controller<PData> {
             handle.shutdown_and_join()?;
         }
         obs_state_join_handle.shutdown_and_join()?;
-        otel_shutdown_handle.shutdown()?;
+        telemetry_system.shutdown()?;
 
         Ok(())
     }

--- a/rust/otap-dataflow/crates/engine/src/testing/processor.rs
+++ b/rust/otap-dataflow/crates/engine/src/testing/processor.rs
@@ -266,7 +266,7 @@ impl<PData: Debug + 'static> TestPhase<PData> {
     {
         let metrics_reporter = self.metrics_system.reporter();
         // Spawn metrics collection loop
-        let (collector, _) = self.metrics_system.into_parts();
+        let collector = self.metrics_system.collector();
         let metrics_collection_handle = self.rt.spawn(collector.run_collection_loop());
 
         // The entire scenario is run to completion before the validation phase

--- a/rust/otap-dataflow/crates/otap/src/parquet_exporter.rs
+++ b/rust/otap-dataflow/crates/otap/src/parquet_exporter.rs
@@ -1507,7 +1507,7 @@ mod test {
         // Run everything on the local task set, including the metrics collector
         let _ = rt.block_on(local.run_until(async move {
             // Start collector in background
-            let (collector, _) = metrics_system.into_parts();
+            let collector = metrics_system.collector();
             let _handle = tokio::task::spawn_local(collector.run_collection_loop());
 
             tokio::join!(

--- a/rust/otap-dataflow/crates/otap/src/signal_type_router.rs
+++ b/rust/otap-dataflow/crates/otap/src/signal_type_router.rs
@@ -397,7 +397,7 @@ mod tests {
             let telemetry_registry = telemetry.registry();
             let reporter = telemetry.reporter();
             let collector_task = tokio::task::spawn_local(async move {
-                let (collector, _) = telemetry.into_parts();
+                let collector = telemetry.collector();
                 let _ = collector.run_collection_loop().await;
             });
             (telemetry_registry, reporter, collector_task)


### PR DESCRIPTION
## Changes
- Remove `into_parts()`
- Remove `TelemetryShutdown` struct and related code to use `InternalTelemetrySystem::shutdown`
- Added `biased` handling in `tokio::select!` to prioritize cancellations